### PR TITLE
Fix for " TypeError: Cannot read properties of undefined (reading 'float')"

### DIFF
--- a/src/server/world/physics.js
+++ b/src/server/world/physics.js
@@ -349,6 +349,13 @@ module.exports = {
 		return true;
 	},
 	hasLos: function (fromX, fromY, toX, toY) {
+		// Fix modules passings invalid floats as args. No effect on integers.
+		fromX = Math.round(fromX);
+		fromY = Math.round(fromY);
+		toX = Math.round(toX);
+		toY = Math.round(toY);
+
+		// Check if out of range.
 		if ((fromX < 0) || (fromY < 0) || (fromX >= this.width) | (fromY >= this.height) || (toX < 0) || (toY < 0) || (toX >= this.width) | (toY >= this.height))
 			return false;
 


### PR DESCRIPTION
The following error is caused by using a float as an array index.
```
TypeError: Cannot read properties of undefined (reading '79.90625')
    at Object.hasLos (/home/vikingman/isleward/src/server/world/physics.js:357:25)
    at Object.cast (/home/vikingman/isleward/src/server/config/spells/spellWarnBlast.js:51:18)
    at Object.castBase (/home/vikingman/isleward/src/server/config/spells/spellTemplate.js:62:15)
    at cast (/home/vikingman/isleward/src/server/components/spellbook/cast.js:112:18)
    at Object.cast (/home/vikingman/isleward/src/server/components/spellbook.js:342:10)
    at Object.performQueue (/home/vikingman/isleward/src/server/objects/objBase.js:265:33)
    at Object.update (/home/vikingman/isleward/src/server/objects/objBase.js:86:9)
    at Object.update (/home/vikingman/isleward/src/server/objects/objects.js:355:7)
    at Object.tick (/home/vikingman/isleward/src/server/world/instancer.js:180:11)
    at listOnTimeout (node:internal/timers:573:17)
```

`Math.round` was used to fix invalid indexes while keeping integers unaffected.