### PR TITLE
Add args for changing port at startup "SRV_PORT=4001 nodejs ./index.js"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Storyline en composition.
 Installation:
 
 1. Cloné le dépot
-2. allé dans src/server/
+2. allé dans `src/server/`
 3. Installé les dépendances: npm install
-4. run: node index.js
-5. allé sur http:://ip:4001/
+4. run: `node index.js` ou `SRV_PORT=4001 nodejs ./index.js` pour choisir le port.
+5. allé sur `http:://ip:4000/` (remplacer 4000 au besoin)
 
 Built with NodeJS, JS, HTML and CSS.
 

--- a/src/server/config/serverConfig.js
+++ b/src/server/config/serverConfig.js
@@ -2,7 +2,7 @@
 
 module.exports = {
 	version: '0',
-	port: 4001,
+	port: process.env.SRV_PORT || 4000,
 	startupMessage: 'Server: ready',
 
 	nodeEnv: process.env.NODE_ENV,


### PR DESCRIPTION
Allows environment variable `SRV_PORT` to override local config server port.
Start test servers with port like so `SRV_PORT=4001 nodejs ./index.js`